### PR TITLE
Fix nullable reference warnings in RemoveTimeout calls

### DIFF
--- a/src/Ziyada/Views/PackageDetailsDialog.cs
+++ b/src/Ziyada/Views/PackageDetailsDialog.cs
@@ -84,7 +84,7 @@ public class PackageDetailsDialog : Dialog
                 var details = await _winget.ShowAsync(_packageId);
                 Application.Invoke(() =>
                 {
-                    Application.RemoveTimeout(pulseTimer);
+                    if (pulseTimer != null) Application.RemoveTimeout(pulseTimer);
                     _progressBar.Visible = false;
 
                     if (details != null)
@@ -107,7 +107,7 @@ public class PackageDetailsDialog : Dialog
             {
                 Application.Invoke(() =>
                 {
-                    Application.RemoveTimeout(pulseTimer);
+                    if (pulseTimer != null) Application.RemoveTimeout(pulseTimer);
                     _progressBar.Visible = false;
                     _statusLabel.Text = "Error loading package details";
                     _detailsView.Text = $"An error occurred: {ex.Message}";

--- a/src/Ziyada/Views/SearchView.cs
+++ b/src/Ziyada/Views/SearchView.cs
@@ -273,7 +273,7 @@ public class SearchView : View
             var installResult = await _winget.InstallAsync(pkg.Id);
             Application.Invoke(() =>
             {
-                Application.RemoveTimeout(pulseTimer);
+                if (pulseTimer != null) Application.RemoveTimeout(pulseTimer);
                 if (!movedToBackground)
                 {
                     // Still showing dialog — update it and close
@@ -309,7 +309,7 @@ public class SearchView : View
         // If user closed after completion (not backgrounded), clean up
         if (!movedToBackground)
         {
-            Application.RemoveTimeout(pulseTimer);
+            if (pulseTimer != null) Application.RemoveTimeout(pulseTimer);
         }
         else
         {


### PR DESCRIPTION
## Summary
Adds null checks before calling `Application.RemoveTimeout()` to fix CS8604 compiler warnings about possible null reference arguments.

## Changes
- **SearchView.cs**: Added null checks at lines 276 and 312
- **PackageDetailsDialog.cs**: Added null checks at lines 87 and 110

## Why
`Application.AddTimeout()` returns `object?` (nullable), but `RemoveTimeout()` expects a non-null `object`. The null checks ensure we only call `RemoveTimeout` when we have a valid timer reference.

## Testing
- Builds without warnings
- No behavioral changes (null check is a safety guard)

---
When merged, this should be released as **v0.2.1** (patch fix, no new features).