### PR TITLE
chore: add Copilot cloud sandbox setup and dev container with hve-core-all

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "Ziyada (.NET 9)",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:1-9.0-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+  "postCreateCommand": "dotnet restore Ziyada.sln && bash .devcontainer/setup-hve-core.sh",
+  "remoteEnv": {
+    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.csdevkit",
+        "GitHub.copilot",
+        "GitHub.copilot-chat"
+      ]
+    }
+  }
+}

--- a/.devcontainer/setup-hve-core.sh
+++ b/.devcontainer/setup-hve-core.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# setup-hve-core.sh
+#
+# Best-effort, non-fatal, idempotent installation of the GitHub Copilot CLI and
+# the hve-core-all plugin (https://github.com/microsoft/hve-core).
+#
+# This script is shared by:
+#   * the Copilot cloud sandbox setup workflow
+#     (.github/workflows/copilot-setup-steps.yml), and
+#   * the dev container (.devcontainer/devcontainer.json).
+#
+# Every step is best-effort: the sandbox and dev container MUST still start even
+# if the Copilot CLI or the plugin cannot be installed (for example when the
+# environment is offline or the CLI has not been authenticated). Failures are
+# therefore downgraded to warnings and never abort the caller.
+set -euo pipefail
+
+echo "==> [hve-core] Ensuring GitHub Copilot CLI is installed"
+command -v copilot >/dev/null 2>&1 || npm install -g @github/copilot || echo "::warning::copilot CLI install failed"
+
+echo "==> [hve-core] Adding microsoft/hve-core plugin marketplace"
+copilot plugin marketplace add microsoft/hve-core || echo "::warning::marketplace add failed"
+
+echo "==> [hve-core] Installing hve-core-all plugin"
+copilot plugin install hve-core-all@hve-core || echo "::warning::hve-core-all install failed"
+
+echo "==> [hve-core] Installed plugins:"
+copilot plugin list || true
+
+echo "==> [hve-core] Setup script complete"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,68 @@
+name: "Copilot Setup Steps"
+
+# Provisions and validates the GitHub Copilot cloud sandbox for this repository.
+# The Copilot coding agent runs the job named exactly `copilot-setup-steps`
+# before it starts working, so this workflow both bootstraps the sandbox and
+# lets us exercise that bootstrap on demand (workflow_dispatch) or whenever the
+# setup files themselves change.
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+      - .devcontainer/setup-hve-core.sh
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+      - .devcontainer/setup-hve-core.sh
+
+permissions:
+  contents: read
+
+jobs:
+  # The job name MUST be `copilot-setup-steps` for the Copilot coding agent to
+  # discover and run it as the sandbox bootstrap.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      # Primary runtime for this repo: .NET 9 (see src/Ziyada/Ziyada.csproj).
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: '9.0.x'
+          cache: true
+          cache-dependency-path: '**/*.csproj'
+
+      # Node is required so the Copilot CLI (an npm package) and the
+      # hve-core-all plugin can be installed, even though this is not a Node repo.
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+
+      - name: Restore .NET dependencies
+        continue-on-error: true
+        run: dotnet restore Ziyada.sln
+
+      - name: Install hve-core-all plugin
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash .devcontainer/setup-hve-core.sh
+
+      - name: Verify tools
+        run: |
+          echo "OS:        $(uname -srm)"
+          echo ".NET SDK:  $(dotnet --version 2>/dev/null || echo 'not installed')"
+          echo "Node:      $(node --version 2>/dev/null || echo 'not installed')"
+          echo "npm:       $(npm --version 2>/dev/null || echo 'not installed')"
+          echo -n "Copilot:   "; copilot --version 2>/dev/null || echo 'not installed'
+          echo "Copilot plugins:"
+          copilot plugin list 2>/dev/null || echo "  (copilot CLI unavailable)"


### PR DESCRIPTION
## What this adds

Three files that give this repo a GitHub Copilot cloud sandbox and a matching dev container, both pre-installing the `hve-core-all` Copilot CLI plugin from [microsoft/hve-core](https://github.com/microsoft/hve-core):

- **`.devcontainer/setup-hve-core.sh`** — shared, best-effort, idempotent installer for the Copilot CLI + `hve-core-all` plugin. Every step is non-fatal (`|| echo ::warning::…` / `|| true`) so the sandbox and dev container still start even if the CLI or plugin can't be installed. Committed with the executable bit (mode `100755`) and LF line endings.
- **`.github/workflows/copilot-setup-steps.yml`** — `Copilot Setup Steps` workflow. Single job named exactly `copilot-setup-steps` on `ubuntu-latest`, with top-level **and** job-level `permissions: contents: read`. Sets up .NET 9 (with NuGet cache) and Node 20, restores dependencies (`continue-on-error`), runs the shared installer (`continue-on-error`, `env: GITHUB_TOKEN: ${{ github.token }}`), and prints tool versions. Triggers: `workflow_dispatch` + `push`/`pull_request` filtered to the setup files.
- **`.devcontainer/devcontainer.json`** — .NET 9 dev container (`mcr.microsoft.com/devcontainers/dotnet:1-9.0-bookworm`) + Node 20 feature; `postCreateCommand` restores deps then runs the shared installer.

## Detected stack

| Aspect | Value |
|---|---|
| Language / runtime | C# / **.NET 9** (`net9.0`) |
| App type | Terminal.Gui v2 TUI for winget (Windows) |
| Solution | `Ziyada.sln` → `src/Ziyada` (Exe) + `tests/Ziyada.Tests` (xUnit) |
| Package manager | NuGet (`dotnet restore`); no lockfile, no `global.json` |
| CI runners (existing) | `windows-latest` |
| Action pinning (existing) | major tags (`@v4`) |

## Build / test / lint commands (from README, CONTRIBUTING, CI)

- **Restore:** `dotnet restore`
- **Build:** `dotnet build --no-restore --configuration Release`
- **Test:** `dotnet test` (xUnit; CI adds `--collect:"XPlat Code Coverage"`)
- **Run:** `dotnet run --project src/Ziyada`
- **Lint:** _no dedicated linter is configured_ (no `dotnet format` step in CI); style is convention-based per `CONTRIBUTING.md`.

## Convention notes / decisions

- **Action pinning:** the repo's existing workflows pin by **major tag** (`@v4`). Following the security best practice for setup workflows, the new workflow **pins third-party actions by full commit SHA** (version in a trailing comment). This is the one intentional deviation from the existing `@v4` convention, using the latest **v4.x.x** of each action to stay consistent with the repo's major versions:
  - `actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0`
  - `actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1`
  - `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0`
- The `.NET` version (`9.0.x`) and NuGet cache (`cache-dependency-path: '**/*.csproj'`) match `release.yml`.
- `devcontainer.json` is strict JSON (no comments) so it validates with `jq`.
- The paths filter also includes `.devcontainer/setup-hve-core.sh` so the workflow re-validates when the shared installer changes.

## Validation

| Check | Result |
|---|---|
| `actionlint .github/workflows/copilot-setup-steps.yml` | ✅ pass (exit 0) |
| `jq` parse + required-keys of `devcontainer.json` | ✅ pass (`true`) |
| Script committed LF + executable | ✅ staged blob CR=0, mode `100755` |
| `dotnet restore` dry-run | ⚠️ not run locally — validation host has the `dotnet` launcher but **no .NET SDK** (`No .NET SDKs were found`). Covered by the workflow's `Setup .NET` step; step is also `continue-on-error`. |
| `devcontainer build` | ⚠️ not run — Docker unavailable on the validation host. Base image tag `1-9.0-bookworm` and the `node:1` feature were confirmed to exist in their registries; `jq` structural validation passed. |
| `copilot-setup-steps` workflow on this PR/branch | ✅ **passed** on a clean `ubuntu-latest` runner (see below) |

## hve-core-all install result — ✅ SUCCESS (clean Ubuntu CI runner)

The `copilot-setup-steps` workflow ran on a fresh `ubuntu-latest` runner (run [`29952428005`](https://github.com/JoshLuedeman/ziyada/actions/runs/29952428005)) and **passed**. The `Install hve-core-all plugin` and `Verify tools` steps show the full headless install succeeding from scratch — the Copilot CLI was **not** pre-installed, so the `npm install -g @github/copilot` path ran and then the plugin installed cleanly:

```
==> [hve-core] Ensuring GitHub Copilot CLI is installed
added 3 packages in 4s
==> [hve-core] Adding microsoft/hve-core plugin marketplace
Marketplace "hve-core" added successfully.
==> [hve-core] Installing hve-core-all plugin
Plugin "hve-core-all" installed successfully.
==> [hve-core] Installed plugins:
Installed plugins:
  • hve-core-all@hve-core (v3.3.101)
==> [hve-core] Setup script complete
```

`Verify tools` step output on the runner:

```
OS:        Linux 6.17.0-1020-azure x86_64
.NET SDK:  10.0.302
Node:      v20.20.2
npm:       10.8.2
Copilot:   GitHub Copilot CLI 1.0.73.
Copilot plugins:
Installed plugins:
  • hve-core-all@hve-core (v3.3.101)
```

Notes:
- **`hve-core-all@hve-core (v3.3.101)` installed successfully** on a clean runner and appears in `copilot plugin list`.
- **`npm install -g @github/copilot` succeeded fresh** (`added 3 packages in 4s`) and **`Marketplace "hve-core" added successfully.`** on first run — confirming the non-fatal fallbacks aren't needed on a clean sandbox.
- **No authentication error** was encountered; the plugin install did not require interactive auth. Every install step is nonetheless `continue-on-error` / non-fatal, so any future auth or network hiccup surfaces a `::warning::` without failing the job.

_(An earlier local dry-run via Git Bash on the Windows validation host also succeeded, but the clean-CI run above is the authoritative result for the cloud sandbox.)_

## Notes

- Auto-merge is **not** enabled.
- Only three files are added; no existing code is modified.
- **Unrelated pre-existing CI failure:** the repo's existing `build-and-test` (`ci.yml`) check is failing on this PR with `NU1202: Package Terminal.Gui 2.4.17 is not compatible with net9.0 … supports: net10.0`. This is caused by `src/Ziyada/Ziyada.csproj` (and the test project) floating `Terminal.Gui` via `Version="2.*"`, which now resolves to the net10.0-only `2.4.17`. It is independent of this PR (this branch touches no `.csproj`/`.sln`/C# code) and would fail on `main` as well. Left unfixed to honor the three-files-only / do-not-modify-unrelated-code scope; a follow-up should pin `Terminal.Gui` to a net9.0-compatible version (e.g. `2.4.16`) or retarget to `net10.0`.
